### PR TITLE
Handle truncated dates and trailing minus in bank statements

### DIFF
--- a/parse_bank_statement.py
+++ b/parse_bank_statement.py
@@ -4,10 +4,23 @@ import re
 import sys
 from datetime import datetime
 
-pattern = re.compile(r"(\d{2}/\d{2}/\d{2})\*?\s+(.*?)\s+(-?\$?\d[\d,]*\.\d{2})")
+# Matches either ``MM/DD/YY`` or ``MM/DD`` followed by a description and amount.
+# Amounts may contain a space after ``$`` and may use a trailing ``-`` to denote
+# a negative value.
+pattern = re.compile(
+    r"^(?:(\d{2}/\d{2}/\d{2})|(\d{2}/\d{2}))\*?\s+(.*?)\s+(-?\$?\s?\d[\d,]*\.\d{2}-?)$"
+)
 
 def parse_pdf(pdf_path):
     rows = []
+    year_hint = None
+
+    # Try to pull a year from the file name as a fallback.  This helps when the
+    # statement omits the year on individual transaction lines.
+    m = re.search(r"(20\d{2})", pdf_path)
+    if m:
+        year_hint = int(m.group(1))
+
     with pdfplumber.open(pdf_path) as pdf:
         for page in pdf.pages:
             text = page.extract_text()
@@ -15,20 +28,43 @@ def parse_pdf(pdf_path):
                 continue
             lines = text.split("\n")
             current = None
+            current_year = year_hint
+
             for line in lines:
                 match = pattern.search(line)
                 if match:
                     if current:
                         rows.append(current)
-                    date_str, desc, amt_str = match.groups()
-                    date_dt = datetime.strptime(date_str, "%m/%d/%y")
+
+                    date_full, date_short, desc, amt_str = match.groups()
+
+                    if date_full:
+                        date_dt = datetime.strptime(date_full, "%m/%d/%y")
+                        current_year = date_dt.year
+                    else:
+                        # Use the most recent year we have seen.  Fallback to
+                        # ``year_hint`` or the current year if necessary.
+                        if current_year is None:
+                            current_year = datetime.today().year
+                        date_dt = datetime.strptime(
+                            f"{date_short}/{str(current_year)[-2:]}", "%m/%d/%y"
+                        )
+
                     date_fmt = f"{date_dt.month}/{date_dt.day}/{date_dt.year}"
-                    is_withdrawal = amt_str.strip().startswith("-")
-                    amount = float(
-                        amt_str.replace("$", "").replace(",", "").replace("+", "").replace("-", "")
+
+                    amt_clean = (
+                        amt_str.replace("$", "")
+                        .replace(",", "")
+                        .replace("+", "")
+                        .replace("-", "")
+                        .strip()
                     )
+                    amount = float(amt_clean)
+
+                    is_withdrawal = amt_str.strip().startswith("-") or amt_str.strip().endswith("-")
                     if is_withdrawal:
                         amount = -amount
+
                     current = {
                         "Date": date_fmt,
                         "Amount": amount,
@@ -37,6 +73,7 @@ def parse_pdf(pdf_path):
                 else:
                     if current:
                         current["Memo"] += " " + line.strip()
+
             if current:
                 rows.append(current)
                 current = None


### PR DESCRIPTION
## Summary
- support statement lines that omit the year (MM/DD format)
- recognize amounts with space after "$" and a trailing minus sign
- infer statement year from filename and transaction context

## Testing
- `python parse_bank_statement.py data/02_2025.pdf /tmp/out.csv && head -n 5 /tmp/out.csv`

------
https://chatgpt.com/codex/tasks/task_e_68aef45ac36483269108b3abb3c861aa