### PR TITLE
Handle truncated dates and trailing minus in bank statements

### DIFF
--- a/parse_bank_statement.py
+++ b/parse_bank_statement.py
@@ -3,32 +3,85 @@ import csv
 import re
 import sys
 from datetime import datetime
+from pathlib import Path
 
-pattern = re.compile(r"(\d{2}/\d{2}/\d{2})\*?\s+(.*?)\s+(-?\$?\d[\d,]*\.\d{2})")
+# Matches either ``MM/DD/YY`` or ``MM/DD`` followed by a description and amount.
+# Amounts may contain a space after ``$`` and may use a trailing ``-`` to denote
+# a negative value.
+pattern = re.compile(
+    r"^(?:(\d{2}/\d{2}/\d{2})|(\d{2}/\d{2}))\*?\s+(.*?)\s+(-?\$?\s?\d[\d,]*\.\d{2}-?)$"
+)
 
-def parse_pdf(pdf_path):
+def parse_pdf(pdf_source):
+    """Parse a bank statement PDF.
+
+    ``pdf_source`` may be a file path or a file-like object.  When a file-like
+    object is provided, the file name (if available) is used to infer the
+    statement year.
+    """
+
     rows = []
-    with pdfplumber.open(pdf_path) as pdf:
+    year_hint = None
+
+    # Try to pull a year from the file name as a fallback. This helps when the
+    # statement omits the year on individual transaction lines.
+    file_name = None
+    if isinstance(pdf_source, (str, Path)):
+        file_name = str(pdf_source)
+    elif hasattr(pdf_source, "name"):
+        file_name = pdf_source.name
+    if file_name:
+        m = re.search(r"(20\d{2})", file_name)
+        if m:
+            year_hint = int(m.group(1))
+
+    if hasattr(pdf_source, "seek"):
+        pdf_source.seek(0)
+
+    with pdfplumber.open(pdf_source) as pdf:
         for page in pdf.pages:
             text = page.extract_text()
             if not text:
                 continue
             lines = text.split("\n")
             current = None
+            current_year = year_hint
+
             for line in lines:
                 match = pattern.search(line)
                 if match:
                     if current:
                         rows.append(current)
-                    date_str, desc, amt_str = match.groups()
-                    date_dt = datetime.strptime(date_str, "%m/%d/%y")
+
+                    date_full, date_short, desc, amt_str = match.groups()
+
+                    if date_full:
+                        date_dt = datetime.strptime(date_full, "%m/%d/%y")
+                        current_year = date_dt.year
+                    else:
+                        # Use the most recent year we have seen.  Fallback to
+                        # ``year_hint`` or the current year if necessary.
+                        if current_year is None:
+                            current_year = datetime.today().year
+                        date_dt = datetime.strptime(
+                            f"{date_short}/{str(current_year)[-2:]}", "%m/%d/%y"
+                        )
+
                     date_fmt = f"{date_dt.month}/{date_dt.day}/{date_dt.year}"
-                    is_withdrawal = amt_str.strip().startswith("-")
-                    amount = float(
-                        amt_str.replace("$", "").replace(",", "").replace("+", "").replace("-", "")
+
+                    amt_clean = (
+                        amt_str.replace("$", "")
+                        .replace(",", "")
+                        .replace("+", "")
+                        .replace("-", "")
+                        .strip()
                     )
+                    amount = float(amt_clean)
+
+                    is_withdrawal = amt_str.strip().startswith("-") or amt_str.strip().endswith("-")
                     if is_withdrawal:
                         amount = -amount
+
                     current = {
                         "Date": date_fmt,
                         "Amount": amount,
@@ -37,6 +90,7 @@ def parse_pdf(pdf_path):
                 else:
                     if current:
                         current["Memo"] += " " + line.strip()
+
             if current:
                 rows.append(current)
                 current = None

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from io import BytesIO
 from pathlib import Path
 import pandas as pd
 from parse_bank_statement import parse_pdf
@@ -13,8 +12,8 @@ uploads = st.file_uploader("Upload PDF(s)", type="pdf", accept_multiple_files=Tr
 if uploads:
     for uploaded in uploads:
         with st.spinner(f"Processing {uploaded.name}. Please wait..."):
-            pdf_bytes = BytesIO(uploaded.read())
-            rows = parse_pdf(pdf_bytes)
+            uploaded.seek(0)
+            rows = parse_pdf(uploaded)
             df = pd.DataFrame(rows)
 
         with st.expander(uploaded.name):


### PR DESCRIPTION
## Summary
- support statement lines that omit the year (MM/DD format)
- recognize amounts with space after "$" and a trailing minus sign
- infer statement year from filename and transaction context
- allow `parse_pdf` to consume file-like objects, enabling Streamlit upload handling

## Testing
- `python parse_bank_statement.py data/02_2025.pdf /tmp/out.csv && head -n 5 /tmp/out.csv`
- `python - <<'PY'
from parse_bank_statement import parse_pdf
from io import BytesIO
with open('data/02_2025.pdf','rb') as f:
    rows = parse_pdf(BytesIO(f.read()))
print(len(rows))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aef45ac36483269108b3abb3c861aa