### PR TITLE
Add selection and sign flip controls

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -17,9 +17,30 @@ if uploads:
             df = pd.DataFrame(rows)
 
         with st.expander(uploaded.name):
-            st.dataframe(df)
+            state_key = f"df_{uploaded.name}"
+            if state_key not in st.session_state:
+                st.session_state[state_key] = df.assign(Selected=False)
+
+            df_state = st.session_state[state_key]
+
+            col1, col2, col3 = st.columns(3)
+            with col1:
+                if st.button("Select All", key=f"select_all_{uploaded.name}"):
+                    df_state["Selected"] = True
+            with col2:
+                if st.button("Clear Selection", key=f"clear_sel_{uploaded.name}"):
+                    df_state["Selected"] = False
+            with col3:
+                if st.button("Flip Signs", key=f"flip_{uploaded.name}"):
+                    df_state.loc[df_state["Selected"], "Amount"] *= -1
+
+            st.session_state[state_key] = df_state
+
+            df_state = st.data_editor(df_state, key=f"editor_{uploaded.name}")
+            st.session_state[state_key] = df_state
+
             csv_name = f"{Path(uploaded.name).stem}.csv"
-            csv_data = df.to_csv(index=False)
+            csv_data = df_state.drop(columns=["Selected"]).to_csv(index=False)
             st.download_button(
                 f"Download {csv_name}",
                 csv_data,


### PR DESCRIPTION
## Summary
- allow selecting all or multiple transactions in the Streamlit app
- add button to flip signs of selected transaction amounts

## Testing
- `python -m py_compile streamlit_app.py parse_bank_statement.py`


------
https://chatgpt.com/codex/tasks/task_e_68aefd46eb148326b25f7cb97e8136a7